### PR TITLE
Jira query should handle custom order by

### DIFF
--- a/src/controllers/jira-controller.php
+++ b/src/controllers/jira-controller.php
@@ -14,7 +14,9 @@ class JiraController extends ControllerBase
             $jiraUrl .= ' and ' . $parameters['jql'];
         }
 
-        $jiraUrl .= ' order by priority';
+        if (substr_count(strtolower($parameters['jql']), "order by") == 0 && substr_count(strtolower($parameters['jql']), "order%20by") == 0) {
+            $jiraUrl .= ' order by priority';
+        }
 
         $client = new GuzzleHttp\Client();
         $res = $client->request('GET', $jiraUrl, [


### PR DESCRIPTION
If a Jira JQL query has its own "order by", don't append the "order by priority". This causes a 500 error in Jira.