### PR TITLE
Session tokens for access and rights control

### DIFF
--- a/doc/Cookies.md
+++ b/doc/Cookies.md
@@ -1,0 +1,12 @@
+# Cookies
+The scrumpoker application uses two types of cookies. One is the *scrum_member_name* and the other are session tokens. Both types and their usage are explained below.
+
+## Scrum Member Name
+This cookie is set and updated everytime a member enters a name to join a session. It is used to prefill the _Name_ box the next time the user open the application. It is only a convenience feature and not necesarry for the overall functionality.
+
+## Session Tokens
+Unlike the member name cookie these cookies are necessary for the app to work. Session tokens are assigned per session and have the key _session-token-{id}_. For private sessions the token is generated from the sessions name and its password, thereby it remains valid if a new session with the same name and password is created. The token for public sessions is generated from random bytes upon creation and returned to the creator.
+
+For private sessions every member needs the token to join and perform operations. They receive the token either through qualified invite or by supplying the password during the join-process. A qualified invite is a Join-URL that includes the token as query parameter like `"?token=XXX"`.
+
+In public sessions the token is returned to the creator and can be passed onto members through qualified invite. In that case the member gains full privilidge, for example to remove other members. If someones joins a public session **without** the token, a member-specific token is generated. That token limits the user to view the current topic, place a vote or remove itself. It does not grant privilidge to start a poll or remove other members. 

--- a/doc/swagger.yaml
+++ b/doc/swagger.yaml
@@ -105,11 +105,11 @@ paths:
       responses:
         '200':
           description: Member removed
-  '/session/haspassword/{id}':
+  '/session/requiresPassword/{id}':
     get:
       tags:
         - session
-      summary: Check if session is protected by password
+      summary: Check if session is protected by password and if it is necessary
       produces:
         - application/json
       parameters:
@@ -121,7 +121,7 @@ paths:
           description: Id of the session that is checked for password protection
       responses:
         '200':
-          description: Boolean if session has a password
+          description: Boolean if session has a password and user does not have a sufficient token
           schema:
             $ref: '#/definitions/BoolResponse'
   '/session/membercheck/{id}/{mid}':

--- a/docker.sh
+++ b/docker.sh
@@ -10,7 +10,7 @@ case $command in
      php bin/composer install
      cp src/sample-config.php src/config.php
      # Overwrite host
-     echo '$host = "localhost:8080";' >> src/config.php
+     echo '$host = "http://localhost:8080";' >> src/config.php
      ;;
   "start")
      running=$(docker ps -a -q)

--- a/src/bootstrap.php
+++ b/src/bootstrap.php
@@ -84,12 +84,18 @@ class ControllerBase
     $this->entityManager->flush();
   }
 
+  // Create a crypto hash for a secret using the name as salt
+  protected function createHash($name, $password)
+  {
+    return crypt($password, $name);
+  }
+
   // The cookie name of the token for a given session
   protected function tokenKey($id)
   {
     return 'session-token-' . $id;
   }
-  
+
   // Make sure the caller has the necesarry token for the operation
   // $memberName indicates that a member token is sufficient for the operation
   // $privateOnly indicates that the token is only required for private sessions
@@ -106,7 +112,7 @@ class ControllerBase
   // Return true if it was and otherwise false
   protected function tokenProvided($session, $memberName = null, $privateOnly = false)
   {
-      // Token only required for private sessions and this is a public one
+    // Token only required for private sessions and this is a public one
     if ($privateOnly && $session->getIsPrivate() == false)
       return true;
 

--- a/src/bootstrap.php
+++ b/src/bootstrap.php
@@ -83,4 +83,48 @@ class ControllerBase
     }
     $this->entityManager->flush();
   }
+
+  // The cookie name of the token for a given session
+  protected function tokenKey($id)
+  {
+    return 'session-token-' . $id;
+  }
+  
+  // Make sure the caller has the necesarry token for the operation
+  // $memberName indicates that a member token is sufficient for the operation
+  // $privateOnly indicates that the token is only required for private sessions
+  protected function verifyToken($session, $memberName = null, $privateOnly = false)
+  {
+    if ($this->tokenProvided($session, $memberName, $privateOnly))
+      return true;
+
+    http_response_code(403); // Return HTTP 403 FORBIDDEN
+    return false;
+  }
+
+  // Check if the token for this session was present in the request
+  // Return true if it was and otherwise false
+  protected function tokenProvided($session, $memberName = null, $privateOnly = false)
+  {
+      // Token only required for private sessions and this is a public one
+    if ($privateOnly && $session->getIsPrivate() == false)
+      return true;
+
+    // Everything else requires a token
+    $tokenKey = $this->tokenKey($session->getId());
+    if (!isset($_COOKIE[$tokenKey]))
+      return false;
+    
+    // Verify token
+    $token = $_COOKIE[$tokenKey];
+    if ($token == $session->getToken())
+      return true;
+
+    // Alternatively compare membertoken if sufficient
+    if ($memberName != null && $token == $this->createHash($memberName, $session->getToken()))
+      return true;
+
+    // Token required but not provided
+    return false;
+  }
 }

--- a/src/controllers/poll-controller.php
+++ b/src/controllers/poll-controller.php
@@ -32,7 +32,12 @@ class PollController extends ControllerBase
   {
     // Fetch entities
     $session = $this->getSession($sessionId);
+    $member = $this->getMember($memberId);
     $currentPoll = $session->getCurrentPoll();
+
+    // Validate token before performing action
+    if (!$this->verifyToken($session, $member->getName()))
+      return;
 
     // Reject votes if poll is completed
     if($currentPoll == null || $currentPoll->getResult() > 0)
@@ -40,20 +45,15 @@ class PollController extends ControllerBase
 
     $method = $_SERVER['REQUEST_METHOD'];
     if ($method == "POST")
-      $this->placeVote($session, $currentPoll, $memberId);
+      $this->placeVote($session, $currentPoll, $member);
     else if ($method == "DELETE")
-      $this->deleteVote($session, $currentPoll, $memberId);
+      $this->deleteVote($session, $currentPoll, $member);
   }
 
   // Place a new vote
-  private function placeVote($session, $currentPoll, $memberId)
+  private function placeVote($session, $currentPoll, $member)
   {
-    $voteValue = $data = $this->jsonInput()["vote"];
-
     include __DIR__ .  "/session-evaluation.php";
-
-    // Fetch member
-    $member = $this->getMember($memberId);
 
     // Find or create vote
     foreach($currentPoll->getVotes() as $vote)
@@ -74,6 +74,7 @@ class PollController extends ControllerBase
     }
 
     // Set value
+    $voteValue = $data = $this->jsonInput()["vote"];
     $voteIndex = $this->getIndex($session, $voteValue);
     $match->setValue($voteIndex);
     
@@ -91,12 +92,12 @@ class PollController extends ControllerBase
   }
 
   // Delete an already placed vote
-  private function deleteVote($session, $currentPoll, $memberId)
+  private function deleteVote($session, $currentPoll, $member)
   {
     // Find the vote of this member
     foreach($currentPoll->getVotes() as $vote)
     {
-      if ($vote->getMember()->getId() == $memberId)
+      if ($vote->getMember() == $member)
       {
         $match = $vote;
         break;
@@ -130,6 +131,10 @@ class PollController extends ControllerBase
       $response->unchanged = true;
       return $response;
     }
+
+    // Validate token only to access the topic of private sessions
+    if (!$this->verifyToken($session, null, true))
+      return;
     
     // Fill response object
     $response->name = $session->getName();
@@ -161,7 +166,11 @@ class PollController extends ControllerBase
       ->setParameter(2, $session);
     $result = $query->getArrayResult();
     foreach($result as $vote)
-      $response->votes[] = UserVote::fromQuery($cardSet, $vote);
+    {
+      $userVote = UserVote::fromQuery($cardSet, $vote);
+      $userVote->canDelete = $this->tokenProvided($session, $userVote->name);
+      $response->votes[] = $userVote;
+    }
     
     return $response;
   }
@@ -172,6 +181,10 @@ class PollController extends ControllerBase
     $method = $_SERVER['REQUEST_METHOD'];
     if ($method == "POST")
     {
+      // Only the sessions owner can start a topic
+      if (!$this->verifyToken($session))
+        return;
+
       $data = $this->jsonInput();        
       $this->startPoll($sessionId, $data["topic"]);
       return null;
@@ -186,6 +199,10 @@ class PollController extends ControllerBase
       $result->unchanged = true;
       return $result;
     }
+
+    // Reading a sessions topic is only protected for private sessions
+    if (!$this->verifyToken($session, null, true))
+      return;
 
     $currentPoll = $session->getCurrentPoll();
 
@@ -209,6 +226,10 @@ class PollController extends ControllerBase
   private function startPoll($sessionId, $topic)
   {
     $session = $this->getSession($sessionId);
+
+    // Only the sessions main token holder can start a poll
+    if (!$this->verifyToken($session))
+      return;
       
     // Start new poll
     $poll = new Poll();

--- a/src/controllers/poll-controller.php
+++ b/src/controllers/poll-controller.php
@@ -178,21 +178,17 @@ class PollController extends ControllerBase
   // Get or set topic of the current poll
   public function topic($sessionId)
   {
+    $session = $this->getSession($sessionId);
+
     $method = $_SERVER['REQUEST_METHOD'];
     if ($method == "POST")
     {
-      // Only the sessions owner can start a topic
-      if (!$this->verifyToken($session))
-        return;
-
       $data = $this->jsonInput();        
-      $this->startPoll($sessionId, $data["topic"]);
+      $this->startPoll($session, $data["topic"]);
       return null;
     }
 
     $result = new stdClass();
-    $session = $this->getSession($sessionId);
-
     // Check if anything changed since the last polling call
     if($this->sessionUnchanged($session))
     {
@@ -223,10 +219,8 @@ class PollController extends ControllerBase
   }
 
   // Start a new poll in the session
-  private function startPoll($sessionId, $topic)
+  private function startPoll($session, $topic)
   {
-    $session = $this->getSession($sessionId);
-
     // Only the sessions main token holder can start a poll
     if (!$this->verifyToken($session))
       return;
@@ -243,8 +237,6 @@ class PollController extends ControllerBase
     
     // Save changes
     $this->saveAll([$session, $poll]);
-    
-    return $poll;
   }
 }
 

--- a/src/controllers/session-controller.php
+++ b/src/controllers/session-controller.php
@@ -34,10 +34,17 @@ class SessionController extends ControllerBase
     $session->setIsPrivate($private);
     if ($private)
       $session->setPassword($this->createHash($data["password"]));
+
+    // Generate the access token and assign it to the session
+    $token = bin2hex(random_bytes(16));
+    $session->setToken($token);
       
     $session->setLastAction(new DateTime());
 
     $this->save($session);
+    
+    $tokenKey = $this->tokenKey($session->getId());
+    setcookie($tokenKey, $token, time()+60*60*24*30);
     
     return new NumericResponse($session->getId());
   }

--- a/src/controllers/session-controller.php
+++ b/src/controllers/session-controller.php
@@ -4,19 +4,22 @@
  */ 
 class SessionController extends ControllerBase
 {
-  private function createHash($password)
-  {
-    return hash('md5', $password);
-  }
-
   // Get all sessions from db
   // URL: /api/session/active
   public function active()
   {
     // Create query finding all active sessions
-    $query = $this->entityManager->createQuery('SELECT s.id, s.name, s.isPrivate, count(m.id) memberCount  FROM Session s LEFT JOIN s.members m WHERE s.lastAction > ?1 GROUP BY s.id');
+    $query = $this->entityManager->createQuery('SELECT s.id, s.name, s.isPrivate, s.token, count(m.id) memberCount  FROM Session s LEFT JOIN s.members m WHERE s.lastAction > ?1 GROUP BY s.id');
     $query->setParameter(1, new DateTime('-1 hour'));
     $sessions = $query->getArrayResult();
+
+    // Determine password requirement for each session
+    foreach($sessions as &$session) {
+      $tokenKey = $this->tokenKey($session["id"]);
+      $session["requiresPassword"] = $session["isPrivate"] 
+        && (!isset($_COOKIE[$tokenKey]) || $_COOKIE[$tokenKey] !== $session["token"]);
+    }
+
     return $sessions;
   }
   
@@ -30,21 +33,20 @@ class SessionController extends ControllerBase
     $session->setName($data["name"]);
     $session->setCardSet($data["cardSet"]);
 
+    // Generate the access token and assign it to the session
     $private = $data["isPrivate"];
     $session->setIsPrivate($private);
     if ($private)
-      $session->setPassword($this->createHash($data["password"]));
-
-    // Generate the access token and assign it to the session
-    $token = bin2hex(random_bytes(16));
+      $token = $this->createHash($data["name"], $data["password"]);
+    else
+      $token = $this->createHash($data["name"], bin2hex(random_bytes(8)));   
     $session->setToken($token);
       
     $session->setLastAction(new DateTime());
 
     $this->save($session);
     
-    $tokenKey = $this->tokenKey($session->getId());
-    setcookie($tokenKey, $token, time()+60*60*24*30);
+    $this->setCookie($session);
     
     return new NumericResponse($session->getId());
   }
@@ -55,9 +57,8 @@ class SessionController extends ControllerBase
   {
     $method = $_SERVER['REQUEST_METHOD'];
     if ($method == "PUT")
-    { 
-      $data = $this->jsonInput();        
-      return $this->addMember($sessionId, $data["name"]);
+    {           
+      return $this->addMember($sessionId);
     }
     if ($method == "DELETE")
     {
@@ -66,10 +67,15 @@ class SessionController extends ControllerBase
   }
   
   // Add a member with this name to the session
-  private function addMember($id, $name)
+  private function addMember($id)
   {   
-    $session = $this->getSession($id);
+    $data = $this->jsonInput();
+    $name = $data["name"];
     
+    $session = $this->getSession($id);
+    $token = $session->getToken();
+    $tokenKey = $this->tokenKey($session->getId());
+
     // Check for existing member
     foreach($session->getMembers() as $candidate)
     {
@@ -78,6 +84,27 @@ class SessionController extends ControllerBase
         $member = $candidate;
         break;
       }  
+    }
+
+    // This blocks check different ways to be granted access
+    if ($this->tokenProvided($session, $name)) {
+      // The user already has the token so we do nothing and continue
+    } else if(isset($_GET["token"]) && $_GET["token"] == $token) {
+      // User supplied the token
+      $this->setCookie($session);
+    } else if(isset($data["password"]) && $token === $this->createHash($session->getName(), $data["password"])) {
+      // Or the password
+      $this->setCookie($session);
+    } else if ($session->getIsPrivate() == false && !isset($member)) {
+      // Tokens are only required to join private sessions,
+      // but without the token the rights are restricted by a member-only token
+      // unless this member already exists
+      $memberToken = $this->createHash($name, $token);
+      $this->setCookie($session, $memberToken);
+    } else {
+      // Return access forbidden otherwise
+      http_response_code(403); // Return HTTP 403 FORBIDDEN
+      return;
     }
 
     // Create new member
@@ -90,11 +117,11 @@ class SessionController extends ControllerBase
         
       $this->saveAll([$member, $session]);
     }
+
+    // Set name cookie for faster login next time
+    setcookie('scrum_member_name', $name, time()+60*60*24*30, "/");
     
-    // Store name in cookie if not done yet
-    // if(!isset($_COOKIE['scrum_member_name']))
-    //   setcookie('scrum_member_name', $name); European privacy law
-    
+    // Create response
     $result = new stdClass();
     $result->sessionId = $id;
     $result->memberId = $member->getId();
@@ -104,15 +131,19 @@ class SessionController extends ControllerBase
   // Remove member from session
   private function removeMember($id)
   {
-    include __DIR__ .  "/session-evaluation.php";
+    // Get member and session
+    $member = $this->getMember($id); 
+    $session = $member->getSession();
 
-    // Get and remove member
-    $member = $this->getMember($id);    
+    if (!$this->verifyToken($session, $member->getName()))
+      return;
+
+    // Get and remove member       
     $this->entityManager->remove($member);
     $this->entityManager->flush();
 
-    // Get the members session and its current poll
-    $session = $member->getSession();
+    // Reevaluate the current poll
+    include __DIR__ .  "/session-evaluation.php";
     $poll = $session->getCurrentPoll();
     if($poll !== null && SessionEvaluation::evaluatePoll($session, $poll))
     {
@@ -128,11 +159,14 @@ class SessionController extends ControllerBase
   }
   
   // Check if session is protected by password
-  // URL: /api/session/haspassword/{id}
-  public function haspassword($id)
+  // This only returns true of the requesting user does not
+  // have the token cookie
+  // URL: /api/session/requiresPassword/{id}
+  public function requiresPassword($id = 0)
   {
     $session = $this->getSession($id);
-    return new BoolResponse($session->getIsPrivate());
+    $requires = $session->getIsPrivate() && !$this->tokenProvided($session);
+    return new BoolResponse($requires);
   }
 
   // Check if member is still part of the session
@@ -154,7 +188,12 @@ class SessionController extends ControllerBase
   {
     $data = $this->jsonInput();
     $session = $this->getSession($id);
-    $result = $session->getPassword() === $this->createHash($data["password"]);
+    $result = $session->getToken() === $this->createHash($session->getName(), $data["password"]);
+
+    // If the correct password was transmitted we grant the token as a reward
+    if ($result)
+      $this->setCookie($session);
+
     return new BoolResponse($result);
   }
 
@@ -171,6 +210,18 @@ class SessionController extends ControllerBase
   public function cardsets()
   {
     return $this->cardSets;
+  }
+
+  // Set the token cookie for this session 
+  // with additional parameters for expiration and path
+  private function setCookie($session, $token = null)
+  {
+    $tokenKey = $this->tokenKey($session->getId());
+
+    if ($token == null)
+      $token = $session->getToken();
+
+    setcookie($tokenKey, $token, time()+60*60*24*30, "/");
   }
 }
 

--- a/src/controllers/statistics-controller.php
+++ b/src/controllers/statistics-controller.php
@@ -20,6 +20,10 @@ class StatisticsController extends ControllerBase
     {
       // Id and session entity
       $session = $this->getSession($id);
+
+      // Reading a private sessions statistic requires the token
+      if (!$this->verifyToken($session, null, true))
+        return;
       
       // Evaluation
       $statistics = [];

--- a/src/controllers/user-vote.php
+++ b/src/controllers/user-vote.php
@@ -38,4 +38,7 @@ class UserVote
   
   // Member must explain his vote
   public $active;
+
+  // Flag if the requesting user has the rights to delete this user (and its vote)
+  public $canDelete;
 }

--- a/src/index.php
+++ b/src/index.php
@@ -79,6 +79,7 @@ foreach($templates as $index=>$template)
 <script src="https://ajax.googleapis.com/ajax/libs/jquery/2.2.4/jquery.min.js"></script>
 <script src="https://ajax.googleapis.com/ajax/libs/angularjs/1.6.4/angular.min.js"></script>
 <script src="https://ajax.googleapis.com/ajax/libs/angularjs/1.6.4/angular-route.min.js"></script>
+<script src="https://ajax.googleapis.com/ajax/libs/angularjs/1.6.4/angular-cookies.min.js"></script>
 <script src="https://ajax.googleapis.com/ajax/libs/angularjs/1.6.4/angular-sanitize.min.js"></script>
 <script src="/js/angular-google-analytics.js"></script>
 <script src="/js//bootstrap.min.js"></script>

--- a/src/js/main.js
+++ b/src/js/main.js
@@ -58,7 +58,7 @@ var scrum = {
 };
 
 // Define angular app
-scrum.app = angular.module('scrum-online', ['ngRoute', 'ngSanitize', 'angular-google-analytics']);
+scrum.app = angular.module('scrum-online', ['ngRoute', 'ngSanitize', 'ngCookies', 'angular-google-analytics']);
 
 //------------------------------
 // Configure routing
@@ -164,7 +164,7 @@ scrum.app.controller('CreateController', function CreateController($http, $locat
 //------------------------------
 // Join controller
 //------------------------------
-scrum.app.controller('JoinController', function JoinController($http, $location, $routeParams) {
+scrum.app.controller('JoinController', function JoinController($http, $location, $routeParams, $cookies) {
   // Save reference to current
   scrum.current = this;
   
@@ -173,6 +173,12 @@ scrum.app.controller('JoinController', function JoinController($http, $location,
   this.idError = false;
   this.name = '';
   this.nameError = false;
+
+  // If the route contains the token, append it to the API call
+  var cookieQuery = '';
+  var cookieValue = $location.search().token;
+  if(cookieValue)
+    cookieQuery = '?token=' + cookieValue;
   
   // Join function
   var self = this;
@@ -187,7 +193,7 @@ scrum.app.controller('JoinController', function JoinController($http, $location,
       return;
     }
     	
-    $http.put('/api/session/member/' + self.id, { name: self.name })
+    $http.put('/api/session/member/' + self.id + cookieQuery, { name: self.name })
       .then(function (response) {
         var result = response.data;
         $location.url('/member/' + result.sessionId + '/' + result.memberId);
@@ -272,7 +278,7 @@ scrum.app.controller('ListController', function($http, $location) {
 //------------------------------
 // Master controller
 //------------------------------
-scrum.app.controller('MasterController', function ($http, $routeParams, $location) {
+scrum.app.controller('MasterController', function ($http, $routeParams, $location, $cookies) {
   // Validate keyring
   $http.get("api/session/haspassword/" + $routeParams.id).then(function (response) {
     if(response.data.success) {
@@ -300,6 +306,10 @@ scrum.app.controller('MasterController', function ($http, $routeParams, $locatio
   this.consensus = false;
   this.sources = scrum.sources;
   this.current = this.sources[0];
+
+  // Fragment for the join url
+  var token = $cookies.get('session-token-' + this.id);
+  this.joinFragment = this.id + '?token=' + token;
   
   // Starting a new poll
   var self = this;

--- a/src/model/session.php
+++ b/src/model/session.php
@@ -13,9 +13,9 @@ class Session
   
     /** @Column(type="boolean") **/
     protected $isPrivate;
-  
-    /** @Column(type="string", nullable=true) **/
-    protected $password;
+
+    /** @Column(type="string") **/
+    protected $token;
 
     /** @Column(type="integer") **/ 
     protected $cardSet;
@@ -56,15 +56,15 @@ class Session
     {
         $this->isPrivate = $isPrivate;
     }
-  
-    // Getter and setter for password field
-    public function getPassword()
+
+    // Getter and setter for the token field
+    public function getToken()
     {
-    	  return $this->password;
+        return $this->token;
     }
-    public function setPassword($password)
+    public function setToken($token)
     {
-        $this->password = $password;
+        $this->token = $token;
     }
 
     // Getter and setter for cardSet field

--- a/src/sample-config.php
+++ b/src/sample-config.php
@@ -9,7 +9,7 @@ $conn = array(
 );
 
 // This is used to create the join link
-$host = "scrumonline.local";
+$host = "https://scrumonline.local";
 
 // Google analytics id
 $ga = 'GOOGLE-ANALYTICS';

--- a/src/templates/home.php
+++ b/src/templates/home.php
@@ -69,7 +69,7 @@ include "config.php";
           <div class="form-group" ng-class="{'has-error': join.idError}">
             <label>Session id:</label>
             <div class="has-feedback">
-              <input type="text" class="form-control" ng-model="join.id" placeholder="4711">
+              <input type="text" class="form-control" ng-model="join.id" ng-change="join.passwordCheck()" placeholder="4711">
               <span ng-if="join.idError" class="glyphicon glyphicon-remove form-control-feedback"></span>
             </div>
           </div>
@@ -78,6 +78,13 @@ include "config.php";
             <div class="has-feedback" ng-init="join.name = '<?= isset($_COOKIE['scrum_member_name']) ? $_COOKIE['scrum_member_name'] : "" ?>'">
               <input type="text" class="form-control"  ng-model="join.name" placeholder="John">
               <span ng-if="join.nameError" class="glyphicon glyphicon-remove form-control-feedback"></span>
+            </div>
+          </div>
+          <div class="form-group" ng-if="join.requiresPassword">
+            <label>Password:</label>
+            <div class="has-feedback">
+              <input type="password" class="form-control"  ng-model="join.password">
+              <span ng-if="join.passwordError" class="glyphicon glyphicon-remove form-control-feedback"></span>
             </div>
           </div>
           <input type="button" class="btn btn-default" value="Join" ng-click="join.joinSession()">

--- a/src/templates/join.php
+++ b/src/templates/join.php
@@ -18,6 +18,13 @@
               <span ng-if="join.nameError" class="glyphicon glyphicon-remove form-control-feedback"></span>
             </div>
           </div>
+          <div class="form-group" ng-if="join.requiresPassword">
+            <label>Password:</label>
+            <div class="has-feedback">
+              <input type="password" class="form-control"  ng-model="join.password">
+              <span ng-if="join.passwordError" class="glyphicon glyphicon-remove form-control-feedback"></span>
+            </div>
+          </div>
           <input type="button" class="btn btn-default" value="Join" ng-click="join.joinSession()">
        </form>
       </div>

--- a/src/templates/master.php
+++ b/src/templates/master.php
@@ -54,9 +54,9 @@ include __DIR__ . "/../config.php";
 <?php
 $joinUrl = "https://". $host . "/join/";
 ?>
-    <img src="https://chart.googleapis.com/chart?chs=300x300&cht=qr&chl=<?= urlencode($joinUrl) . "{{ master.id }}" ?>&choe=UTF-8" title="Join {{ master.id }}" />
+    <img src="https://chart.googleapis.com/chart?chs=300x300&cht=qr&chl=<?= urlencode($joinUrl) . "{{ master.joinFragment }}" ?>&choe=UTF-8" title="Join {{ master.id }}" />
 <?php
-$joinUrl = $joinUrl . "{{ master.id }}";
+$joinUrl = $joinUrl . "{{ master.joinFragment }}";
 ?>
     <p>Or send them this link: <a href="<?= $joinUrl ?>"><?= $joinUrl ?></a>
   </div>

--- a/src/templates/master.php
+++ b/src/templates/master.php
@@ -36,7 +36,7 @@ include __DIR__ . "/../config.php";
               <div class="inner"><span class="card-label" ng-bind-html="vote.value"></span></div>
             </div>
           </div>
-          <div class="delete-member remove selectable" ng-click="master.remove(vote.id)">
+          <div ng-if="vote.canDelete" class="delete-member remove selectable" ng-click="master.remove(vote.id)">
             <span class="glyphicon glyphicon-remove"></span>
           </div>
         </div>
@@ -52,7 +52,7 @@ include __DIR__ . "/../config.php";
     <h2>Invite members</h2>
     <p>Invite members to join your session. Session id: <strong ng-bind="master.id"></strong></p>
 <?php
-$joinUrl = "https://". $host . "/join/";
+$joinUrl = $host . "/join/";
 ?>
     <img src="https://chart.googleapis.com/chart?chs=300x300&cht=qr&chl=<?= urlencode($joinUrl) . "{{ master.joinFragment }}" ?>&choe=UTF-8" title="Join {{ master.id }}" />
 <?php


### PR DESCRIPTION
This refactoring of the code base will finally add basic rights management by assigning session tokens which are evaluated in different API calls.

Necessary changes:
- [X] Create token for each session and return to creator
- [x] Pass token to every member joining a private session using password
- [x] Require token for actions like removing members, starting a poll, ...