### PR TITLE
Bugfix for import Sponsors.php

### DIFF
--- a/src/index.php
+++ b/src/index.php
@@ -1,7 +1,7 @@
 <?php
 include "config.php";
 include "templates/templates.php";
-include "sponsors.php";
+
 
 $templates = Template::getAll();
 


### PR DESCRIPTION
Remove import for sponsors.php. Since this file does not exist and leads to errors when executed