### PR TITLE
Modify .gitignore to accept composer.lock file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@ vendor/
 node_modules/
 src/config.php
 *.lock
+!composer.lock
 proxies/
 .vagrant/
 mysql_db


### PR DESCRIPTION
Referring to the contained file `composer.lock`, which should not be included in the repo by `.gitignore`, I modify the `.gitignore` to explicitly include the `composer.lock`.

Alternaitv the entry `*.lock` from the .gitignore can be omitted or the file `composer.lock` can be removed from the repo.

But since there are advantages for `composer.lock` to fix the used dependencies, I plead for the adaptation of `.gitignore`. Since an update of the `composer.lock` would have to be done by an explicit update, there should be no risk of the regular inclusion of the file in version control.

With reference to: https://getcomposer.org/doc/01-basic-usage.md#commit-your-composer-lock-file-to-version-control