### PR TITLE
Close poll manually

### DIFF
--- a/src/controllers/session-evaluation.php
+++ b/src/controllers/session-evaluation.php
@@ -5,12 +5,12 @@
 class SessionEvaluation
 {
     // Evaluate the polls average
-  public static function evaluatePoll($session, $currentPoll)
+  public static function evaluatePoll($session, $currentPoll, $force = false)
   {
     $sum = 0;
     $count = $currentPoll->getVotes()->count();
     
-    if($count <= 0 || $count != $session->getMembers()->count())
+    if (!$force && ($count <= 0 || $count != $session->getMembers()->count()))
       return false;
     
     foreach($currentPoll->getVotes() as $vote)

--- a/src/controllers/user-vote.php
+++ b/src/controllers/user-vote.php
@@ -4,7 +4,7 @@ class UserVote
   private function __construct()
   {
     $this->placed = false;
-    $this->value = 0;
+    $this->value = 'N/A';
     $this->active = false;
   }
   

--- a/src/js/main.js
+++ b/src/js/main.js
@@ -335,6 +335,11 @@ scrum.app.controller('MasterController', function ($http, $routeParams, $locatio
       self.stopwatch();
     });
   };
+
+  // Force stop a poll
+  this.stopPoll = function () {
+    $http.post('/api/poll/close/' + self.id);
+  };
   
   // Remove a member from the session
   this.remove = function (id) {

--- a/src/templates/default_source.html
+++ b/src/templates/default_source.html
@@ -8,4 +8,5 @@
     <input type="text" class="form-control" ng-model="master.current.description" placeholder="The user can create an awesome foo">
   </div>
   <button class="btn btn-default" ng-click="master.startPoll(master.current.topic, master.current.description)">Start</button>
+  <button class="btn btn-default" ng-click="master.stopPoll()">Stop</button>
 </form>

--- a/src/templates/github_source.html
+++ b/src/templates/github_source.html
@@ -62,7 +62,8 @@
           <div class="panel-body" style="white-space: pre-line" ng-bind-html="master.current.issue.body"></div>
         </div>
         
-        <button class="btn btn-default" ng-click="master.startPoll(master.current.issue.title, master.current.issue.body, master.current.issue.html_url">Start</button>
+        <button class="btn btn-default" ng-click="master.startPoll(master.current.issue.title, master.current.issue.body, master.current.issue.html_url)">Start</button>
+        <button class="btn btn-default" ng-click="master.stopPoll()">Stop</button>
       </div>
   </div>
 </div>

--- a/src/templates/gitlab_source.html
+++ b/src/templates/gitlab_source.html
@@ -63,6 +63,7 @@
         </div>
         
         <button class="btn btn-default" ng-click="master.startPoll(master.current.issue.title, master.current.issue.description, master.current.issue.web_url)">Start</button>
+        <button class="btn btn-default" ng-click="master.stopPoll()">Stop</button> 
       </div>
   </div>
 </div>

--- a/src/templates/jira_source.html
+++ b/src/templates/jira_source.html
@@ -79,6 +79,7 @@
       </div>
 
       <button class="btn btn-default" ng-click="master.startPoll(master.current.issue.key + ' ' + master.current.issue.fields.summary, master.current.issue.fields.description, master.current.base_url + '/browse/' + master.current.issue.key)">Start</button>
+      <button class="btn btn-default" ng-click="master.stopPoll()">Stop</button> 
     </div>
   </div>
 </div>


### PR DESCRIPTION
Raised in #134 sometimes a member of the team might be away from the screen and the scrum master still wants to close the poll. This PR adds a new API endpoint to close the current poll and adds a `Stop` button to the poll control.

It also fixes a previously unreported bug in the github integration.

Closes #134.