### PR TITLE
Add docker support (closes #147)

### DIFF
--- a/.env
+++ b/.env
@@ -1,0 +1,13 @@
+SCRUMONLINE_ENABLE_FORK_BANNER=true
+SCRUMONLINE_ENABLE_QR_CODE=true
+
+# ===================================================
+# ===== CHANGES BELOW THIS LINE NOT RECOMMENDED =====
+# ===================================================
+MYSQL_HOST=db
+MYSQL_DATABASE=scrum_online
+MYSQL_USER=user
+MYSQL_PASSWORD=passwd
+MYSQL_ROOT_PASSWORD=secret
+MYSQL_CHECK_DATABASE=mysql
+MYSQL_CHECK_TABLE="select * from user"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,74 @@
+FROM php:7.4-apache
+
+# propagate environment vars from .env file
+ENV MYSQL_HOST $MYSQL_HOST \
+    MYSQL_ROOT_PASSWORD $MYSQL_ROOT_PASSWORD \
+    MYSQL_DATABASE $MYSQL_DATABASE \
+    MYSQL_USER $MYSQL_USER \
+    MYSQL_PASSWORD $MYSQL_PASSWORD \
+    MYSQL_CHECK_TABLE $MYSQL_CHECK_TABLE \
+    MYSQL_CHECK_DATABASE $MYSQL_CHECK_DATABASE
+
+# update existing packages / install required packages / cleanup
+RUN apt-get -y update \
+    && apt-get -y install zip default-mysql-client\
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/* \
+    && a2enmod rewrite \
+    && curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
+
+# Install database connection extensions
+RUN docker-php-ext-install mysqli pdo_mysql
+
+#  create vhost
+RUN printf "\n\
+<VirtualHost *:80> \n\
+        DocumentRoot /var/www/html/src \n\
+ \n\
+        <Directory /var/www/html/src> \n\
+           AllowOverride All \n\
+           Require all granted  \n\
+        </Directory> \n\
+ \n\
+        ErrorLog ${APACHE_LOG_DIR}/error.log \n\
+        CustomLog ${APACHE_LOG_DIR}/access.log combined \n\
+</VirtualHost> \n\
+" > /etc/apache2/sites-enabled/000-default.conf
+
+# add project specific files
+COPY . /var/www/html
+
+# copy sample configuration
+RUN cp /var/www/html/src/sample-config.php /var/www/html/src/config.php
+
+# overwrite previous (sample) configuration (redundant definition of $conn feeded by environment)
+RUN printf "\n\
+\n\
+// docker specific database configuration parameters \n\
+\$conn = array( \n\
+    'dbname' => \$_ENV['MYSQL_DATABASE'], \n\
+    'user' => \$_ENV['MYSQL_USER'], \n\
+    'password' => \$_ENV['MYSQL_PASSWORD'], \n\
+    'host' => \$_ENV['MYSQL_HOST'], \n\
+    'driver' => 'pdo_mysql', \n\
+); \n\
+ \n\
+\$layout_switch = [ \n\
+    'enable_fork_banner' => \$_ENV['SCRUMONLINE_ENABLE_FORK_BANNER'], \n\
+    'enable_qr_code' => \$_ENV['SCRUMONLINE_ENABLE_QR_CODE'] \n\
+]; \n\
+ \n\
+" >> /var/www/html/src/config.php
+
+# change workdir
+WORKDIR /var/www/html
+
+# initialize project
+RUN composer install
+# the following commands need a working container network/name resolution; moved to entrypoint
+#RUN ./vendor/bin/doctrine orm:generate-proxies
+#RUN ./vendor/bin/doctrine orm:schema-tool:create
+
+# execute entrypoint
+RUN chmod +x /var/www/html/entrypoint.sh
+CMD ["/var/www/html/entrypoint.sh"]

--- a/README.md
+++ b/README.md
@@ -21,6 +21,18 @@ For every story the Scrum Master will than start a poll and each member of the s
 * Statistics tab in navigation bar
 * Mobile apps with watch support. Imagine voting on Android Wear or Apple Watch. Wouldn't that be cool? :D
 
+## Quick Installation (docker based)
+
+The quick installation can be done with the included Docker configurations. In the Docker configuration, three systems are initiated and booted: the HTTP service with the software Scrumonline, the required database service based on MySQL and optionally a pypmyadmin.
+
+In order to terminate, recreate and start any running containers of Scrumonline the following commands have to be called in the Scrumonline directory:
+
+``` bash
+docker-compose down && docker-compose build --no-cache && docker-compose up
+```
+
+Please wait until the console displays `Scrumonline is now accessible. Have a nice time!` appears. The Scrumonline provided by the container can now be reached by calling the address `http://localhost:8001` in your browser.
+
 ## Contribute
 If you want to contribute you can just clone the repository and follow the deployment instructions. Any changes must be commited to a fork and then merged by issuing a pull request. For information on the REST API or ticketing plugins please have a look at the [wiki documentation](https://github.com/Toxantron/scrumonline/blob/master/doc/).
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,46 @@
+version: "3"
+services:
+    www:
+        build: .
+        ports:
+            - "8001:80"
+        environment:
+            # reading environment vars from .env file
+            MYSQL_HOST: ${MYSQL_HOST}
+            MYSQL_DATABASE: ${MYSQL_DATABASE}
+            MYSQL_USER: ${MYSQL_USER}
+            MYSQL_PASSWORD: ${MYSQL_PASSWORD}
+            MYSQL_ROOT_PASSWORD: ${MYSQL_ROOT_PASSWORD}
+            MYSQL_CHECK_DATABASE: ${MYSQL_CHECK_DATABASE}
+            MYSQL_CHECK_TABLE: ${MYSQL_CHECK_TABLE}
+        links:
+            - db:db
+        network_mode: bridge
+        restart: unless-stopped
+
+    db:
+        image: mysql:8.0.16
+        command: ['--character-set-server=utf8mb4', '--collation-server=utf8mb4_unicode_ci','--default-authentication-plugin=mysql_native_password']
+        ports:
+            - "3306:3306"
+        environment:
+            # reading environment vars from .env file
+            MYSQL_DATABASE: ${MYSQL_DATABASE}
+            MYSQL_USER: ${MYSQL_USER}
+            MYSQL_PASSWORD: ${MYSQL_PASSWORD}
+            MYSQL_ROOT_PASSWORD: ${MYSQL_ROOT_PASSWORD}
+        network_mode: bridge
+        restart: unless-stopped
+
+    phpmyadmin:
+        image: phpmyadmin/phpmyadmin:4.8
+        links:
+            - db:db
+        ports:
+            - 8000:80
+        environment:
+            # reading environment vars from .env file
+            MYSQL_USER: ${MYSQL_USER}
+            MYSQL_PASSWORD: ${MYSQL_PASSWORD}
+            MYSQL_ROOT_PASSWORD: ${MYSQL_ROOT_PASSWORD}
+        network_mode: bridge

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,0 +1,51 @@
+#!/bin/bash
+COUNT_LOOPS=0
+MAX_LOOPS=120
+WAIT_TIME=5
+
+# change base dir
+cd /var/www/html
+
+echo "Waiting for database service: checking database '${MYSQL_CHECK_DATABASE}'..."
+
+ROWS=$(mysql -h ${MYSQL_HOST} -uroot -p${MYSQL_ROOT_PASSWORD} ${MYSQL_CHECK_DATABASE} -e "${MYSQL_CHECK_TABLE}"| grep -v ERROR | wc -l)
+ROWS="${ROWS:-0}"
+
+while [ $ROWS -eq 0 ]
+do
+    COUNT_LOOPS=$((COUNT_LOOPS+1))
+
+    echo "Waiting for database connection... ($COUNT_LOOPS/$MAX_LOOPS)"
+    sleep ${WAIT_TIME}
+
+    ROWS=$(mysql -h db -uroot -p${MYSQL_ROOT_PASSWORD} ${MYSQL_CHECK_DATABASE} -e "${MYSQL_CHECK_TABLE}"| grep -v ERROR | wc -l)
+    ROWS="${ROWS:-0}"
+
+    if [ $COUNT_LOOPS -gt $MAX_LOOPS ]; then
+        # loop limit reached
+        echo "No database connection etablished. Abort."
+        exit 1
+    fi
+done
+
+echo "Database connection established! Proceeding..."
+
+# check if first run
+CONTAINER_ALREADY_STARTED="CONTAINER_ALREADY_STARTED_PLACEHOLDER"
+if [ ! -e $CONTAINER_ALREADY_STARTED ]; then
+    touch $CONTAINER_ALREADY_STARTED
+    echo "Container started first time. Initializing Scrumonline..."
+    # wait 
+    composer install
+    ./vendor/bin/doctrine orm:generate-proxies
+    ./vendor/bin/doctrine orm:schema-tool:create
+fi
+
+echo "Starting web service..."
+echo ""
+echo "################################################################"
+echo "#####                                                      #####"
+echo "#####   Scrumonline is now accessible. Have a nice time!   #####"
+echo "#####                                                      #####"
+echo "################################################################"
+/usr/sbin/apache2ctl -D FOREGROUND


### PR DESCRIPTION
...I've been naughty ;) 

I set up the docker branch as PR to show that the support is trouble-free and not very complex. The maintenance of these four files should only require a small effort in future releases. 

I think the added value is very high and supports future CI/CD pipelines for automatic testing. Adjustments can be made by the user in the `.env' file. Updates regarding new versions of the services can be made by the contributors in the docker-compose.yml. However, this should be limited to changing the version numbers.

For further details I also have a version of the README, which explains the containers and the variables in detail. But in the current state the extension works without any adjustment.

Despite your answer I suggest the files in the hope to convince you to put the Docker support back to the upstream. If it still seems too complex, do whatever you want with them ;)

(in reference to #147)
